### PR TITLE
Fix undefined *channel_id variables if composer root not found

### DIFF
--- a/plugin/phpcd.vim
+++ b/plugin/phpcd.vim
@@ -2,6 +2,8 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 let g:phpcd_need_update = 0
+let g:phpcd_channel_id = -1
+let g:phpid_channel_id = -1
 
 function! GetComposerRoot() " {{{
 	let root = getcwd()


### PR DESCRIPTION
Starting nvim from outside of composer project leads to early exit in plugin/phpcd.vim, as result *channel_id variables are not defined, which leads to errors further down the road:

> Error detected while processing function phpcd#CompletePHP:
> line    2:
> E121: Undefined variable: g:phpcd_channel_id
> Error detected while processing function phpcd#CompletePHP:
> line    2:
> E15: Invalid expression: g:phpcd_channel_id < 0
> Error detected while processing function phpcd#CompletePHP:
> line    2:
> E121: Undefined variable: g:phpcd_channel_id
> Error detected while processing function phpcd#CompletePHP:
> line    2:
> E15: Invalid expression: g:phpcd_channel_id < 0
> Error detected while processing function
> phpcd#CompletePHP..phpcd#GetCurrentNameSpace:
> line    1:
> E121: Undefined variable: g:phpcd_channel_id
> Error detected while processing function
> phpcd#CompletePHP..phpcd#GetCurrentNameSpace:
> line    1:
> E116: Invalid arguments for function rpcrequest(g:phpcd_channel_id, 'nsuse', expand('%:p'))
> Error detected while processing function
> phpcd#CompletePHP..phpcd#GetCurrentNameSpace:
> line    1: 
> E15: Invalid expression: rpcrequest(g:phpcd_channel_id, 'nsuse', expand('%:p'))

But may be better way is to check if variables exist?