### PR TITLE
generate namespace and class name according psr4

### DIFF
--- a/autoload/phpcd.vim
+++ b/autoload/phpcd.vim
@@ -44,6 +44,13 @@ function! phpcd#CompletePHP(findstart, base) " {{{
 	try " {{{
 		let winheight = winheight(0)
 		let winnr = winnr()
+		if context =~? '^namespace'
+			return phpcd#GetPsrNamespace()
+		endif
+
+		if context =~? '\v^(abstract\s+)?(class|interface|trait)'
+			return [expand('%:t:r')]
+		end
 
 		let [current_namespace, imports] = phpcd#GetCurrentNameSpace()
 
@@ -88,6 +95,10 @@ function! phpcd#CompletePHP(findstart, base) " {{{
 	finally
 		silent! exec winnr.'resize '.winheight
 	endtry " }}}
+endfunction " }}}
+
+function! phpcd#GetPsrNamespace() " {{{
+	return rpcrequest(g:phpcd_channel_id, 'psr4ns', expand('%:p'))
 endfunction " }}}
 
 function! phpcd#CompleteGeneral(base, current_namespace, imports) " {{{

--- a/php/PHPCD.php
+++ b/php/PHPCD.php
@@ -6,7 +6,6 @@ class PHPCD extends RpcServer
     const MATCH_HEAD        = 'match_head';
 
     private $matchType;
-    private $root;
 
     /**
      * Set type of matching
@@ -27,8 +26,7 @@ class PHPCD extends RpcServer
 
     public function __construct($root)
     {
-        $this->root = $root;
-        parent::__construct();
+        parent::__construct($root);
 
         /** Set default match type **/
         $this->setMatchType(self::MATCH_SUBSEQUENCE);

--- a/php/PHPID.php
+++ b/php/PHPID.php
@@ -2,18 +2,6 @@
 
 class PHPID extends RpcServer
 {
-    /**
-     * set the composer root dir(containing vendor)
-     *
-     * @param string $root the path
-     * @return static
-     */
-    public function setRoot($root)
-    {
-        $this->root = $root;
-        return $this;
-    }
-
     public function loop()
     {
         $this->index();

--- a/php/RpcServer.php
+++ b/php/RpcServer.php
@@ -17,13 +17,32 @@ class RpcServer
 
     private $log_file;
 
-    public function __construct()
+    /**
+     * Composer root dir(containing vendor)
+     */
+    protected $root;
+
+    public function __construct($root)
     {
+        $this->setRoot($root);
         $log_path = getenv('HOME') . '/.phpcd.log';
         $this->log_file = fopen($log_path, 'a');
         $this->unpacker = new MessagePackUnpacker;
 
         register_shutdown_function([$this, 'shutdown']);
+    }
+
+    /**
+     * Set the composer root dir
+     *
+     * @param string $root the path
+     * @return static
+     */
+    protected function setRoot($root)
+    {
+        // @TODO do we need to validate this input variable?
+        $this->root = $root;
+        return $this;
     }
 
     public function loop()

--- a/php/phpcd_main.php
+++ b/php/phpcd_main.php
@@ -7,4 +7,4 @@ require __DIR__ . '/RpcServer.php';
 require __DIR__ . '/PHPCD.php';
 require __DIR__ . '/Reflection/ReflectionClass.php';
 
-(new PHPCD)->loop();
+(new PHPCD($argv[1]))->loop();

--- a/php/phpcd_main.php
+++ b/php/phpcd_main.php
@@ -1,10 +1,11 @@
 <?php
 error_reporting(0);
 
-require $argv[1] . '/vendor/autoload.php';
+$root = $argv[1];
 
+require $root . '/vendor/autoload.php';
 require __DIR__ . '/RpcServer.php';
 require __DIR__ . '/PHPCD.php';
 require __DIR__ . '/Reflection/ReflectionClass.php';
 
-(new PHPCD($argv[1]))->loop();
+(new PHPCD($root))->loop();

--- a/php/phpid_main.php
+++ b/php/phpid_main.php
@@ -7,4 +7,4 @@ require $root . '/vendor/autoload.php';
 require __DIR__ . '/RpcServer.php';
 require __DIR__ . '/PHPID.php';
 
-(new PHPID)->setRoot($root)->loop();
+(new PHPID($root))->loop();


### PR DESCRIPTION
According PSR-4, the class's namespace is namespace prefix (defined in composer.json) plus file relative path, and the class's name is the file name. So, if we create a php file according the psr4, the namespace is also determined.

This PR give phpcd the ability to generate the psr4 namespace and class automatically. After type in the namespace or class, just type `C-x C-o` to generate the namespace and classname.