### PR TITLE
Dirty fix for missing argument

### DIFF
--- a/php/PHPCD.php
+++ b/php/PHPCD.php
@@ -89,7 +89,7 @@ class PHPCD implements RpcHandler
      * @var string $static_mode see translateStaticMode method
      * @var bool $public_only
      */
-    public function info($class_name, $pattern, $static_mode = 'both', $public_only)
+    public function info($class_name, $pattern, $static_mode = 'both', $public_only = true)
     {
         if ($class_name) {
             $static_mode = $this->translateStaticMode($static_mode);


### PR DESCRIPTION
after recent update i started getting following error

> [2016-06-21 00:50:11] PHPCD.ERROR: Missing argument 4 for PHPCD\PHPCD::info() [{"file":"/home/Xerkus/.config/nvim/plugins/phpcd.vim/php/PHPCD.php","line":92,"function":"{closure}","args":[2,"Missing argument 4 for PHPCD\\PHPCD::info()","/home/Xerkus/.config/nvim/plugins/phpcd.vim/php/PHPCD.php",92,{"class_name":"","pattern":"true","static_mode":"both"}]},{"function":"info","class":"PHPCD\\PHPCD","type":"->","args":["","true"]},{"file":"/home/Xerkus/.config/nvim/plugins/phpcd.vim/vendor/lvht/msgpack-rpc/src/AbstractServer.php","line":78,"function":"call_user_func_array","args":[["[object] (PHPCD\\PHPCD: {})","info"],["","true"]]},{"file":"/home/Xerkus/.config/nvim/plugins/phpcd.vim/vendor/lvht/msgpack-rpc/src/AbstractServer.php","line":58,"function":"doRequest","class":"Lvht\\MsgpackRpc\\ForkServer","type":"->","args":[["[object] (PHPCD\\PHPCD: {})","info"],["","true"]]},{"file":"/home/Xerkus/.config/nvim/plugins/phpcd.vim/vendor/lvht/msgpack-rpc/src/AbstractServer.php","line":38,"function":"onRequest","class":"Lvht\\MsgpackRpc\\ForkServer","type":"->","args":[[0,17,"info",["","true"]]]},{"file":"/home/Xerkus/.config/nvim/plugins/phpcd.vim/vendor/lvht/msgpack-rpc/src/ForkServer.php","line":43,"function":"onMessage","class":"Lvht\\MsgpackRpc\\ForkServer","type":"->","args":[[0,17,"info",["","true"]]]},{"file":"/home/Xerkus/.config/nvim/plugins/phpcd.vim/php/main.php","line":43,"function":"loop","class":"Lvht\\MsgpackRpc\\ForkServer","type":"->","args":[]}] []

php does not allow required parameters after optional, so i just made it optional too.
Whatever code is invoking `info()` should probably be fixed but i have no time atm to figure what it is
