### PR TITLE
Ensure index dir created before writing

### DIFF
--- a/php/PHPID.php
+++ b/php/PHPID.php
@@ -179,6 +179,12 @@ class PHPID implements RpcHandler
 
     private function saveChild($index_file, $child)
     {
+        $index_directory = dirname($index_file);
+
+        if (is_dir($index_directory)) {
+            mkdir($index_directory, 0755, true);
+        }
+
         if (is_file($index_file)) {
             $childs = json_decode(file_get_contents($index_file));
         } else {


### PR DESCRIPTION
Writing a file to a directory that does not exist will always error,
preventing the index from being cached.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/phpvim/phpcd.vim/54)
<!-- Reviewable:end -->
